### PR TITLE
chore: expose rollkit rpc for docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,11 @@ services:
   rollkit-evm-single:
     image: ghcr.io/rollkit/rollkit-evm-single:pr-2394
     container_name: rollkit-evm-single
-    entrypoint: /usr/bin/entrypoint.sh
+    entrypoint: /scripts/entrypoint.sh
+    ports:
+      - "7331:7331"
     volumes:
+      - ./testnet/rollkit/entrypoint.sh:/scripts/entrypoint.sh:ro
       - evm-single-data:/data
     environment:
       - EVM_ENGINE_URL=http://reth:8551

--- a/testnet/rollkit/entrypoint.sh
+++ b/testnet/rollkit/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+cd /usr/bin
+
+sleep 5
+
+# Create default rollkit config if missing
+if [ ! -f "$HOME/.evm-single/config/signer.json" ]; then
+  ./evm-single init --rollkit.node.aggregator=true --rollkit.signer.passphrase $EVM_SIGNER_PASSPHRASE
+fi
+
+# Conditionally add --rollkit.da.address if ROLLKIT_DA_ADDRESS is set
+da_flag=""
+if [ -n "$DA_ADDRESS" ]; then
+  da_flag="--rollkit.da.address $DA_ADDRESS"
+fi
+
+# Conditionally add --rollkit.da.auth_token if ROLLKIT_DA_AUTH_TOKEN is set
+da_auth_token_flag=""
+if [ -n "$DA_AUTH_TOKEN" ]; then
+  da_auth_token_flag="--rollkit.da.auth_token $DA_AUTH_TOKEN"
+fi
+
+# Conditionally add --rollkit.da.namespace if ROLLKIT_DA_NAMESPACE is set
+da_namespace_flag=""
+if [ -n "$DA_NAMESPACE" ]; then
+  da_namespace_flag="--rollkit.da.namespace $DA_NAMESPACE"
+fi
+
+exec ./evm-single start \
+  --evm.jwt-secret $EVM_JWT_SECRET \
+  --evm.genesis-hash $EVM_GENESIS_HASH \
+  --evm.engine-url $EVM_ENGINE_URL \
+  --evm.eth-url $EVM_ETH_URL \
+  --rollkit.node.block_time $EVM_BLOCK_TIME \
+  --rollkit.node.aggregator=true \
+  --rollkit.rpc.address "0.0.0.0:7331" \
+  --rollkit.signer.passphrase $EVM_SIGNER_PASSPHRASE \
+  $da_flag \
+  $da_auth_token_flag \
+  $da_namespace_flag


### PR DESCRIPTION
## Overview

Exposes rollkit's rpc listen address. Default host: 127.0.0.1 needs to be: 0.0.0.0 host
Requires copying the entrypoint script as its not easily extendable. I opened an issue in rollkit.

With this I can query store metadata to get the da included height:

```
curl -X POST \
  -H "Content-Type: application/json" \
  -d '{"key": "rhb/100/h"}' \
  http://localhost:7331/rollkit.v1.StoreService/GetMetadata
{"value":"HgAAAAAAAAA="}                                                                              
```

This value seems to be base64 encoded little endian bytes of the uint64: 30