### PR TITLE
Enhance: Skip Empty blocks

### DIFF
--- a/crates/ev-prover/src/prover/programs/block.rs
+++ b/crates/ev-prover/src/prover/programs/block.rs
@@ -379,6 +379,9 @@ impl BlockExecProver {
             async move {
                 let mut tasks = JoinSet::new();
                 while let Some(scheduled) = sched_rx.recv().await {
+                    if scheduled.job.blobs.is_empty() {
+                        continue;
+                    }
                     let prover = prover.clone();
                     let permit = prove_sem.clone().acquire_owned().await.unwrap();
                     tasks.spawn(async move {


### PR DESCRIPTION
If I understand correctly then it is fine if we skip empty blocks and only prove those that have EVM transactions / blobs in them. 

The condition for a proof to be valid is that the trusted root must be correct (which doesn't change if there are no transactions) and that the target height is > the trusted height.