### PR TITLE
Fix: Limit Indexer Range to 100k

### DIFF
--- a/crates/ev-prover/src/prover/config.rs
+++ b/crates/ev-prover/src/prover/config.rs
@@ -7,6 +7,7 @@ use tracing::warn;
 // TODO: move these values to config.yaml
 pub const BATCH_SIZE: u64 = 100;
 pub const MIN_BATCH_SIZE: u64 = 10;
+pub const MAX_BATCH_SIZE: u64 = 100000;
 pub const WARN_DISTANCE: u64 = 1500;
 pub const MAX_INDEXING_RANGE: u64 = 100000;
 

--- a/crates/ev-prover/src/prover/programs/batch.rs
+++ b/crates/ev-prover/src/prover/programs/batch.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use crate::prover::abi::MailboxContract;
 use crate::prover::chain::ChainContext;
-use crate::prover::config::MAX_INDEXING_RANGE;
+use crate::prover::config::{MAX_BATCH_SIZE, MAX_INDEXING_RANGE};
 use crate::prover::{
     config::{BATCH_SIZE, MIN_BATCH_SIZE, WARN_DISTANCE},
     MessageProofRequest, MessageProofSync, ProverConfig, RangeProofCommitted,
@@ -298,7 +298,7 @@ impl BatchExecProver {
             if current_mailbox_nonce > *mailbox_nonce {
                 // Ensure batch size meets minimum requirement
                 let blocks_elapsed = height.saturating_sub(trusted_celestia_height);
-                let batch_size = blocks_elapsed.max(MIN_BATCH_SIZE);
+                let batch_size = blocks_elapsed.clamp(MIN_BATCH_SIZE, MAX_BATCH_SIZE);
                 *mailbox_nonce = current_mailbox_nonce;
                 debug!("Found non-empty block at height {height}, adjusting batch size to {batch_size}");
                 return Ok(batch_size);


### PR DESCRIPTION
@damiannolan As we discussed, this PR fixes the max range exceeded error in the indexer, by batching max. 100k blocks at a time.

I made the max range configurable the same way that we currently configure the batch sizes.